### PR TITLE
Use under-scored script_dir for setup.cfg

### DIFF
--- a/door_adapter_switchbot/setup.cfg
+++ b/door_adapter_switchbot/setup.cfg
@@ -1,7 +1,7 @@
 [develop]
-script-dir=$base/lib/door_adapter_switchbot
+script_dir=$base/lib/door_adapter_switchbot
 [install]
-install-scripts=$base/lib/door_adapter_switchbot
+install_scripts=$base/lib/door_adapter_switchbot
 [flake8]
 aggressive = 2
 ignore = W503, ANN002, ANN003, ANN1, C801


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

ビルド時のWarningを防ぐための修正

```
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
  warnings.warn(
/usr/lib/python3/dist-packages/setuptools/dist.py:723: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead
  warnings.warn(
```